### PR TITLE
Import React in a allowSyntheticDefaultImports: false friendly way.

### DIFF
--- a/packages/accessibility/src/components/HiddenText/HiddenText.tsx
+++ b/packages/accessibility/src/components/HiddenText/HiddenText.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 interface Props {
   id: string;

--- a/packages/accessibility/src/components/LiveRegion/LiveRegion.tsx
+++ b/packages/accessibility/src/components/LiveRegion/LiveRegion.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 export interface Props {
   id: string;

--- a/packages/core/src/components/Accessibility/Accessibility.tsx
+++ b/packages/core/src/components/Accessibility/Accessibility.tsx
@@ -1,4 +1,5 @@
-import React, {useEffect, useMemo, useState} from 'react';
+import * as React from 'react';
+import {useEffect, useMemo, useState} from 'react';
 import {createPortal} from 'react-dom';
 import {useUniqueId} from '@dnd-kit/utilities';
 import {HiddenText, LiveRegion, useAnnouncement} from '@dnd-kit/accessibility';

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -1,4 +1,5 @@
-import React, {
+import * as React from 'react';
+import {
   memo,
   createContext,
   useCallback,

--- a/packages/core/src/components/DragOverlay/DragOverlay.tsx
+++ b/packages/core/src/components/DragOverlay/DragOverlay.tsx
@@ -1,4 +1,5 @@
-import React, {useContext} from 'react';
+import * as React from 'react';
+import {useContext} from 'react';
 
 import {applyModifiers, Modifiers} from '../../modifiers';
 import {ActiveDraggableContext} from '../DndContext';

--- a/packages/core/src/components/DragOverlay/components/AnimationManager/AnimationManager.tsx
+++ b/packages/core/src/components/DragOverlay/components/AnimationManager/AnimationManager.tsx
@@ -1,4 +1,5 @@
-import React, {cloneElement, useState} from 'react';
+import * as React from 'react';
+import {cloneElement, useState} from 'react';
 import {useIsomorphicLayoutEffect, usePrevious} from '@dnd-kit/utilities';
 
 import type {UniqueIdentifier} from '../../../../types';

--- a/packages/core/src/components/DragOverlay/components/NullifiedContextProvider/NullifiedContextProvider.tsx
+++ b/packages/core/src/components/DragOverlay/components/NullifiedContextProvider/NullifiedContextProvider.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import type {Transform} from '@dnd-kit/utilities';
 
 import {InternalContext, defaultInternalContext} from '../../../../store';

--- a/packages/core/src/components/DragOverlay/components/PositionedOverlay/PositionedOverlay.tsx
+++ b/packages/core/src/components/DragOverlay/components/PositionedOverlay/PositionedOverlay.tsx
@@ -1,4 +1,5 @@
-import React, {forwardRef} from 'react';
+import * as React from 'react';
+import {forwardRef} from 'react';
 import {CSS, isKeyboardEvent} from '@dnd-kit/utilities';
 
 import type {Transform} from '@dnd-kit/utilities';

--- a/packages/sortable/src/components/SortableContext.tsx
+++ b/packages/sortable/src/components/SortableContext.tsx
@@ -1,4 +1,5 @@
-import React, {useEffect, useMemo, useRef} from 'react';
+import * as React from 'react';
+import {useEffect, useMemo, useRef} from 'react';
 import {useDndContext, ClientRect, UniqueIdentifier} from '@dnd-kit/core';
 import {useIsomorphicLayoutEffect, useUniqueId} from '@dnd-kit/utilities';
 


### PR DESCRIPTION
Otherwise you'll see the following error:

```
node_modules/@dnd-kit/core/dist/components/DndContext/DndContext.d.ts:1:8 - error TS1259: Module '"node_modules/@types/react/index"' can only be default-imported using the 'allowSyntheticDefaultImports' flag

1 import React from 'react';
         ~~~~~

  node_modules/@types/react/index.d.ts:62:1
    62 export = React;
       ~~~~~~~~~~~~~~~
    This module is declared with using 'export =', and can only be used with a default import when using the 'allowSyntheticDefaultImports' flag
```